### PR TITLE
Add initial contribution guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,40 @@
 # dirac-swift-api
 Repository for the REST API side of the DiRAC-SWIFT project
+
+# Contributing
+
+To contribute to the project as a developer, use the following as a guide. These are based on ARC Collaborations [group practices](https://github.com/UCL-ARC/research-software-documentation/blob/main/processes/programming_projects/group_practices.md) and [code review documentation](https://github.com/UCL-ARC/research-software-documentation/blob/main/processes/programming_projects/review.md).
+
+## Python standards we follow
+
+To make explicit some of the potentially implicit:
+
+- We will target Python versions `>= 3.10`
+- We will use linters and static type checkers to increase the legibility of the code produced here
+- Function arguments and return types will be annotated to enable the above (with type checking via [mypy](https://mypy.readthedocs.io/en/stable/))
+- We will use [docstrings](https://peps.python.org/pep-0257/) to annotate classes, class methods and functions
+  - If you use Visual Studio Code, [autoDocstring](https://marketplace.visualstudio.com/items?itemName=njpwerner.autodocstring) is recommended to speed this along.
+
+## General GitHub workflow
+
+- Create a branch for each new piece of work with a suitable descriptive name, such as `feature-newgui` or `adding-scaffold`
+- Do all work on this branch
+- Open a new PR for that branch to contain discussion about your changes
+  - Do this **early** and set as a 'Draft PR' (on GitHub) until you are ready to merge to make your work visible to other developers
+- Make sure the repository has CI configured so tests (ideally both of the branch, and of the PR when merged) are run on every push.
+- If you need advice, mention @reviewer and ask questions in a PR comment.
+- When ready for merge, request a review from the "Reviewer" menu on the PR.
+- All work must go through a pull-request review before reaching `main`
+  - **Never** commit or push directly to `main`
+
+The `main` branch is for ready-to-deploy release quality code
+
+- Any team member can review (but not the PR author)
+  - try to cycle this around so that everyone becomes familiar with the code
+- Try to cycle reviewers around the project's team: so that all members get familiar with all work.
+- Once a reviewer approves your PR, **you** can hit the merge button
+- Default to a 'Squash Merge', adding your changes to the main branch as a single commit that can be easily rolled back if need be
+
+## Reviewing code
+
+[The Turing Way](https://the-turing-way.netlify.app/index.html) provides an overview of best practices - it comes as recommended reading and includes some [possible workflows for code review](https://the-turing-way.netlify.app/reproducible-research/reviewing/reviewing-checklist.html?highlight=code%20review) - great if you're unsure what you're typically looking for during a code review.


### PR DESCRIPTION
Not wanting to impose this on the team and definitely looking to make this collaborative - I've thrown together a few best practices but happy to tweak things. Thought it would be best to agree early on things like github workflow & python standards, and the list definitely will need expanding.