### PR TITLE
Avoid serializing new _handle attribute of units class.

### DIFF
--- a/src/api/processing/metadata.py
+++ b/src/api/processing/metadata.py
@@ -69,7 +69,6 @@ def create_swift_metadata(filename: str, units: RemoteSWIFTUnits | SWIFTUnits) -
     -------
         bytes: Pickled SWIFTMetadata object
     """
-
     metadata = SWIFTMetadata(filename, units)
     if hasattr(metadata.units, "_handle"):
         metadata.units._handle = None  # do not serialize file handle

--- a/src/api/processing/metadata.py
+++ b/src/api/processing/metadata.py
@@ -69,7 +69,10 @@ def create_swift_metadata(filename: str, units: RemoteSWIFTUnits | SWIFTUnits) -
     -------
         bytes: Pickled SWIFTMetadata object
     """
+
     metadata = SWIFTMetadata(filename, units)
+    if hasattr(metadata.units, "_handle"):
+        metadata.units._handle = None  # do not serialize file handle
 
     try:
         return cloudpickle.dumps(metadata)

--- a/src/api/processing/units.py
+++ b/src/api/processing/units.py
@@ -179,6 +179,7 @@ def create_swift_units(filename: Path) -> bytes:
 
     Args:
         filename (Path): File path of specified HDF5 file
+
     Raises
     ------
         RemoteSWIFTUnitsError: Raised in case of failed JSON serialisation.

--- a/src/api/processing/units.py
+++ b/src/api/processing/units.py
@@ -118,6 +118,8 @@ def retrieve_units_json_compatible(filename: str) -> dict:
         dict: JSON-serialisable units dictionary.
     """
     units = SWIFTUnits(filename)
+    if hasattr(units, "_handle"):
+        units._handle = None  # do not serialize file handle
     return convert_swift_units_dict_types(units.__dict__)
 
 


### PR DESCRIPTION
A recent addition to swiftsimio is the `_handle` attribute for the `SWIFTUnits` class. This contains an h5py file handle and is therefore not serializable (nor do we need to make it serializable). If present, it's set to `None` before serialization.